### PR TITLE
Enum support

### DIFF
--- a/recap-derive/src/lib.rs
+++ b/recap-derive/src/lib.rs
@@ -1,11 +1,14 @@
 extern crate proc_macro;
 
+use std::collections::HashMap;
+
 use proc_macro::TokenStream;
 use proc_macro2::Span;
 use quote::quote;
 use regex::Regex;
 use syn::{
-    parse_macro_input, Data::Struct, DataStruct, DeriveInput, Fields, Ident, Lit, Meta, NestedMeta,
+    parse_macro_input, Data::Enum, Data::Struct, DataEnum, DataStruct, DeriveInput, Fields, Ident,
+    Lit, Meta, NestedMeta,
 };
 
 #[proc_macro_derive(Recap, attributes(recap))]
@@ -26,118 +29,334 @@ pub fn derive_recap(item: TokenStream) -> TokenStream {
     let (impl_generics, ty_generics, where_clause) = item.generics.split_for_impl();
 
     let has_lifetimes = item.generics.lifetimes().count() > 0;
-    let impl_from_str = if !has_lifetimes {
-        quote! {
-            impl #impl_generics std::str::FromStr for #item_ident #ty_generics #where_clause {
-                type Err = recap::Error;
-                fn from_str(s: &str) -> Result<Self, Self::Err> {
-                    recap::lazy_static! {
-                        static ref RE: recap::Regex = recap::Regex::new(#regex)
-                            .expect("Failed to compile regex");
+    let out = match regex {
+        Regexes::StructRegex(regex) => {
+            let impl_from_str = if !has_lifetimes {
+                quote! {
+                    impl #impl_generics std::str::FromStr for #item_ident #ty_generics #where_clause {
+                        type Err = recap::Error;
+                        fn from_str(s: &str) -> Result<Self, Self::Err> {
+                            recap::lazy_static! {
+                                static ref RE: recap::Regex = recap::Regex::new(#regex)
+                                    .expect("Failed to compile regex");
+                            }
+
+                            recap::from_captures(&RE, s)
+                        }
                     }
-
-                    recap::from_captures(&RE, s)
                 }
+            } else {
+                quote! {}
+            };
+
+            let lifetimes = item.generics.lifetimes();
+            let also_lifetimes = item.generics.lifetimes();
+            let impl_inner = quote! {
+                impl #impl_generics std::convert::TryFrom<& #(#lifetimes)* str> for #item_ident #ty_generics #where_clause {
+                    type Error = recap::Error;
+                    fn try_from(s: & #(#also_lifetimes)* str) -> Result<Self, Self::Error> {
+                        recap::lazy_static! {
+                            static ref RE: recap::Regex = recap::Regex::new(#regex)
+                                .expect("Failed to compile regex");
+                        }
+
+                        recap::from_captures(&RE, s)
+                    }
+                }
+                #impl_from_str
+            };
+
+            let impl_matcher = quote! {
+                impl #impl_generics  #item_ident #ty_generics #where_clause {
+                    /// Recap derived method. Returns true when some input text
+                    /// matches the regex associated with this type
+                    pub fn is_match(input: &str) -> bool {
+                        recap::lazy_static! {
+                            static ref RE: recap::Regex = recap::Regex::new(#regex)
+                                .expect("Failed to compile regex");
+                        }
+                        RE.is_match(input)
+                    }
+                }
+            };
+
+            let injector = Ident::new(
+                &format!("RECAP_IMPL_FOR_{}", item.ident.to_string()),
+                Span::call_site(),
+            );
+
+            quote! {
+                const #injector: () = {
+                    extern crate recap;
+                    #impl_inner
+                    #impl_matcher
+                };
             }
         }
-    } else {
-        quote! {}
-    };
+        Regexes::EnumRegexes(regexes) => {
+            let impl_from_str = if !has_lifetimes {
+                let from_str_regexes = regexes.iter().map(|(variant_name, regex)| {
+                    let regex_name_injector = Ident::new(
+                        &format!("RE_{}", variant_name),
+                        Span::call_site(),
+                    );
+                    quote! {
+                            static ref #regex_name_injector: recap::Regex = recap::Regex::new(#regex)
+                                .expect("Failed to compile regex");
+                    }
+                });
 
-    let lifetimes = item.generics.lifetimes();
-    let also_lifetimes = item.generics.lifetimes();
-    let impl_inner = quote! {
-        impl #impl_generics std::convert::TryFrom<& #(#lifetimes)* str> for #item_ident #ty_generics #where_clause {
-            type Error = recap::Error;
-            fn try_from(s: & #(#also_lifetimes)* str) -> Result<Self, Self::Error> {
-                recap::lazy_static! {
-                    static ref RE: recap::Regex = recap::Regex::new(#regex)
-                        .expect("Failed to compile regex");
+                let try_parse_regexes = regexes.iter().map(|(variant_name, regex)| {
+                    let regex_name_injector =
+                        Ident::new(&format!("RE_{}", variant_name), Span::call_site());
+                    quote! {
+                        if let Some(caps) = #regex_name_injector.captures(&s) {
+                            return Ok(#variant_name {
+
+                            })
+                        }
+                    }
+                });
+
+                quote! {
+                    impl #impl_generics std::str::FromStr for #item_ident #ty_generics #where_clause {
+                        type Err = recap::Error;
+                        fn from_str(s: &str) -> Result<Self, Self::Err> {
+                            recap::lazy_static! {
+                                #(#from_str_regexes)*
+                            }
+
+                            #(#try_parse_regexes)*
+
+                            panic!("AAAAHHHHH");
+                        }
+                    }
                 }
+            } else {
+                quote! {}
+            };
 
-                recap::from_captures(&RE, s)
+            let lifetimes = item.generics.lifetimes();
+            let also_lifetimes = item.generics.lifetimes();
+            let impl_inner = {
+                let from_str_regexes = regexes.iter().map(|(variant_name, regex)| {
+                    let regex_name_injector = Ident::new(
+                        &format!("RE_{}", variant_name),
+                        Span::call_site(),
+                    );
+                    quote! {
+                            static ref #regex_name_injector: recap::Regex = recap::Regex::new(&#regex)
+                                .expect("Failed to compile regex");
+                    }
+                });
+
+                let try_parse_regexes = regexes.keys().map(|variant_name| {
+                    let regex_name_injector =
+                        Ident::new(&format!("RE_{}", variant_name), Span::call_site());
+                    quote! {
+                        match recap::from_captures(&#regex_name_injector, s) {
+                            Ok(value) => {return Ok(value)},
+                            Err(e) => {
+                                panic!("{}", e);
+                            }
+                        };
+                    }
+                });
+
+                quote! {
+                    impl #impl_generics std::convert::TryFrom<& #(#lifetimes)* str> for #item_ident #ty_generics #where_clause {
+                        type Error = recap::Error;
+                        fn try_from(s: & #(#also_lifetimes)* str) -> Result<Self, Self::Error> {
+                            recap::lazy_static! {
+                                #(#from_str_regexes)*
+                            }
+                            #(#try_parse_regexes)*
+                            panic!("AAAAHHHHH");
+                        }
+                    }
+                    #impl_from_str
+                }
+            };
+            let impl_matcher = {
+                let from_str_regexes = regexes.iter().map(|(variant_name, regex)| {
+                    let regex_name_injector = Ident::new(
+                        &format!("RE_{}", variant_name),
+                        Span::call_site(),
+                    );
+                    quote! {
+                            static ref #regex_name_injector: recap::Regex = recap::Regex::new(#regex)
+                                .expect("Failed to compile regex");
+                    }
+                });
+
+                let matchers = regexes.iter().map(|(variant_name, regex)| {
+                    let regex_name_injector =
+                        Ident::new(&format!("RE_{}", variant_name), Span::call_site());
+                    quote! {
+                        if #regex_name_injector.is_match(input) {
+                            return true;
+                        };
+                    }
+                });
+
+                quote! {
+                impl #impl_generics  #item_ident #ty_generics #where_clause {
+                    /// Recap derived method. Returns true when some input text
+                    /// matches the regex associated with this type
+                    pub fn is_match(input: &str) -> bool {
+                            recap::lazy_static! {
+                                #(#from_str_regexes)*
+                            }
+                            #(#matchers)*
+                            false
+                        }
+                    }
+                }
+            };
+
+            let injector = Ident::new(
+                &format!("RECAP_IMPL_FOR_{}", item.ident.to_string()),
+                Span::call_site(),
+            );
+
+            quote! {
+                const #injector: () = {
+                    extern crate recap;
+                    #impl_inner
+                    #impl_matcher
+                };
             }
         }
-        #impl_from_str
-    };
-
-    let impl_matcher = quote! {
-        impl #impl_generics  #item_ident #ty_generics #where_clause {
-            /// Recap derived method. Returns true when some input text
-            /// matches the regex associated with this type
-            pub fn is_match(input: &str) -> bool {
-                recap::lazy_static! {
-                    static ref RE: recap::Regex = recap::Regex::new(#regex)
-                        .expect("Failed to compile regex");
-                }
-                RE.is_match(input)
-            }
-        }
-    };
-
-    let injector = Ident::new(
-        &format!("RECAP_IMPL_FOR_{}", item.ident.to_string()),
-        Span::call_site(),
-    );
-
-    let out = quote! {
-        const #injector: () = {
-            extern crate recap;
-            #impl_inner
-            #impl_matcher
-        };
+        _ => panic!("Made it this far"),
     };
 
     out.into()
 }
 
+enum Regexes {
+    StructRegex(String),
+    EnumRegexes(HashMap<String, String>),
+}
+
 fn validate(
     item: &DeriveInput,
-    regex: &str,
+    regex_container: &Regexes,
 ) {
-    let regex = Regex::new(regex).unwrap_or_else(|err| {
-        panic!(
-            "Invalid regular expression provided for `{}`\n{}",
-            &item.ident, err
-        )
-    });
-    let caps = regex.capture_names().flatten().count();
-    let fields = match &item.data {
-        Struct(DataStruct {
-            fields: Fields::Named(fs),
-            ..
-        }) => fs.named.len(),
-        _ => panic!("Recap regex can only be applied to Structs with named fields"),
-    };
-    if caps != fields {
-        panic!(
+    match regex_container {
+        Regexes::StructRegex(regex) => {
+            let regex = Regex::new(regex).unwrap_or_else(|err| {
+                panic!(
+                    "Invalid regular expression provided for `{}`\n{}",
+                    &item.ident, err
+                )
+            });
+            let caps = regex.capture_names().flatten().count();
+            let fields = match &item.data {
+                Struct(DataStruct {
+                    fields: Fields::Named(fs),
+                    ..
+                }) => fs.named.len(),
+                _ => {
+                    panic!("Recap regex can only be applied to Structs and Enums with named fields")
+                }
+            };
+            if caps != fields {
+                panic!(
             "Recap could not derive a `FromStr` impl for `{}`.\n\t\t > Expected regex with {} named capture groups to align with struct fields but found {}",
             item.ident, fields, caps
         );
+            }
+        }
+        Regexes::EnumRegexes(regexes) => {
+            match &item.data {
+                Enum(DataEnum { variants, .. }) => {
+                    for variant in variants {
+                        let variant_name = format!("{}", variant.ident);
+                        match regexes.get(&variant_name) {
+                            Some(regex) => {
+                                let regex = Regex::new(regex).unwrap_or_else(|err| {
+                                    panic!(
+                                        "Invalid regular expression provided for `{}`\n{}",
+                                        &item.ident, err
+                                    )
+                                });
+                                let caps = regex.capture_names().flatten().count();
+                                let fields = variant.fields.len();
+                                if caps != fields {
+                                    panic!(
+            "Recap could not derive a `FromStr` impl for `{}`.\n\t\t > Expected regex with {} named capture groups to align with struct fields but found {}",
+            item.ident, fields, caps
+        );
+                                }
+                            }
+                            None => panic!("Recap regex missing on enum variant {}", variant_name),
+                        }
+                    }
+                }
+                _ => {
+                    panic!("Recap regex can only be applied to Structs and Enums with named fields")
+                }
+            };
+        }
     }
 }
 
-fn extract_regex(item: &DeriveInput) -> Option<String> {
-    item.attrs
-        .iter()
-        .flat_map(syn::Attribute::parse_meta)
-        .filter_map(|x| match x {
-            Meta::List(y) => Some(y),
-            _ => None,
-        })
-        .filter(|x| x.path.is_ident("recap"))
-        .flat_map(|x| x.nested.into_iter())
-        .filter_map(|x| match x {
-            NestedMeta::Meta(y) => Some(y),
-            _ => None,
-        })
-        .filter_map(|x| match x {
-            Meta::NameValue(y) => Some(y),
-            _ => None,
-        })
-        .find(|x| x.path.is_ident("regex"))
-        .and_then(|x| match x.lit {
-            Lit::Str(y) => Some(y.value()),
-            _ => None,
-        })
+fn extract_regex(item: &DeriveInput) -> Option<Regexes> {
+    match &item.data {
+        Struct(DataStruct {
+            fields: Fields::Named(fs),
+            ..
+        }) => item
+            .attrs
+            .iter()
+            .flat_map(syn::Attribute::parse_meta)
+            .filter_map(|x| match x {
+                Meta::List(y) => Some(y),
+                _ => None,
+            })
+            .filter(|x| x.path.is_ident("recap"))
+            .flat_map(|x| x.nested.into_iter())
+            .filter_map(|x| match x {
+                NestedMeta::Meta(y) => Some(y),
+                _ => None,
+            })
+            .filter_map(|x| match x {
+                Meta::NameValue(y) => Some(y),
+                _ => None,
+            })
+            .find(|x| x.path.is_ident("regex"))
+            .and_then(|x| match x.lit {
+                Lit::Str(y) => Some(Regexes::StructRegex(y.value())),
+                _ => None,
+            }),
+        Enum(DataEnum {
+            enum_token,
+            brace_token,
+            variants,
+        }) => {
+            let mut regexes: HashMap<String, String> = HashMap::new();
+            for variant in variants {
+                let variant_name = format!("{}", variant.ident);
+                for attr in variant.attrs.iter() {
+                    if attr.path.is_ident("recap") {
+                        let meta = attr.parse_meta().unwrap();
+                        if let Meta::List(meta_list) = meta {
+                            for nested_meta in meta_list.nested {
+                                if let syn::NestedMeta::Meta(syn::Meta::NameValue(nv)) = nested_meta
+                                {
+                                    if nv.path.is_ident("regex") {
+                                        if let syn::Lit::Str(lit_str) = nv.lit {
+                                            regexes.insert(variant_name.clone(), lit_str.value());
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            Some(Regexes::EnumRegexes(regexes))
+        }
+        _ => None,
+    }
 }

--- a/recap-derive/src/lib.rs
+++ b/recap-derive/src/lib.rs
@@ -109,6 +109,7 @@ pub fn derive_recap(item: TokenStream) -> TokenStream {
                 let try_parse_regexes = regexes.iter().map(|(variant_name, regex)| {
                     let regex_name_injector =
                         Ident::new(&format!("RE_{}", variant_name), Span::call_site());
+
                     quote! {
                         if let Some(caps) = #regex_name_injector.captures(&s) {
                             return Ok(#variant_name {

--- a/recap-derive/src/lib.rs
+++ b/recap-derive/src/lib.rs
@@ -157,7 +157,7 @@ pub fn derive_recap(item: TokenStream) -> TokenStream {
 
                             #(#parsers)*
 
-                            Err(Self::Err::Custom("Uh Oh".to_string()))
+                            Err(Self::Err::Custom("Unable to parse command".to_string()))
                         }
                     }
                 }
@@ -177,7 +177,7 @@ pub fn derive_recap(item: TokenStream) -> TokenStream {
                             }
                             #(#parsers)*
 
-                            Err(Self::Error::Custom("Uh Oh".to_string()))
+                            Err(Self::Error::Custom("Unable to parse command".to_string()))
                         }
                     }
                     #impl_from_str

--- a/recap/examples/enum.rs
+++ b/recap/examples/enum.rs
@@ -1,0 +1,29 @@
+use recap::Recap;
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Recap)]
+#[recap(regex = r"^(?P<room_name>\d+)\s(?P<room_capacity>\d+)")]
+struct TestCommand {
+    room_name: String,
+    room_capacity: usize,
+}
+
+#[derive(Deserialize, Serialize, Debug, Recap)]
+enum Command {
+    #[recap(regex = r"^/join\s(?P<user_id>.+)")]
+    Join(String),
+    #[recap(regex = r"^/send\s(?P<room_id>\d+)\s(?P<message>.*)")]
+    SendMessage { message: String, room_id: usize },
+    #[recap(regex = r"^/test\s(?P<test>.+)")]
+    CreateRoom(TestCommand),
+    #[recap(regex = r"^/ping")]
+    Ping,
+}
+
+fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let send_message: Command = "/send 5458 Hello, World!".parse()?;
+    if let Command::SendMessage { message, room_id } = send_message {
+        println!("Room({room_id}):{message}")
+    };
+    Ok(())
+}

--- a/recap/src/lib.rs
+++ b/recap/src/lib.rs
@@ -359,13 +359,9 @@ where
     let caps = re.captures(input).ok_or_else(|| {
         envy::Error::Custom(format!("No captures resolved in string '{}'", input))
     })?;
-    from_iter(
-        re.capture_names()
-            .map(|maybe_name| {
-                maybe_name.and_then(|name| caps.name(name).map(|val| (name, val.as_str())))
-            })
-            .flatten(),
-    )
+    from_iter(re.capture_names().filter_map(|maybe_name| {
+        maybe_name.and_then(|name| caps.name(name).map(|val| (name, val.as_str())))
+    }))
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Add the ability to parse enums using recap:
```rust
#[derive(Deserialize, Serialize, Debug, Recap)]
enum Command {
    #[recap(regex = r"^/join\s(?P<user_id>.+)")]
    Join(String),
    #[recap(regex = r"^/send\s(?P<room_id>\d+)\s(?P<message>.*)")]
    SendMessage { message: String, room_id: usize },
    #[recap(regex = r"^/create\s(?P<test>.+)")]
    CreateRoom(TestCommand),
    #[recap(regex = r"^/ping")]
    Ping,
}
```